### PR TITLE
OSM ID over Flickr picture

### DIFF
--- a/src/main/java/io/jawg/osmcontributor/flickr/oauth/OAuthRequest.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/oauth/OAuthRequest.java
@@ -58,7 +58,7 @@ public class OAuthRequest {
     /*----------------CODE---------------------*/
     /*=========================================*/
     public void initParam(Map<String, String> params) {
-        this.params.clear();
+        this.params = new TreeMap<>();
         this.params.put("oauth_consumer_key", apiKey);
         for (Map.Entry<String, String> param : params.entrySet()) {
             this.params.put(param.getKey(), param.getValue());

--- a/src/main/java/io/jawg/osmcontributor/flickr/oauth/OAuthRequest.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/oauth/OAuthRequest.java
@@ -85,7 +85,9 @@ public class OAuthRequest {
         for (Map.Entry<String, String> param: params.entrySet()) {
             url.append(param.getKey()).append("=").append(param.getValue()).append("&");
         }
-        url.deleteCharAt(url.lastIndexOf("&"));
+        if (url.lastIndexOf("&") >= 0) {
+            url.deleteCharAt(url.lastIndexOf("&"));
+        }
         return url.toString();
     }
 

--- a/src/main/java/io/jawg/osmcontributor/flickr/oauth/OAuthRequest.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/oauth/OAuthRequest.java
@@ -85,8 +85,10 @@ public class OAuthRequest {
         for (Map.Entry<String, String> param: params.entrySet()) {
             url.append(param.getKey()).append("=").append(param.getValue()).append("&");
         }
-        if (url.lastIndexOf("&") >= 0) {
-            url.deleteCharAt(url.lastIndexOf("&"));
+
+        int lastIndexEsp = url.lastIndexOf("&");
+        if (lastIndexEsp >= 0) {
+            url.deleteCharAt(lastIndexEsp);
         }
         return url.toString();
     }

--- a/src/main/java/io/jawg/osmcontributor/flickr/rest/FlickrAddTagClient.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/rest/FlickrAddTagClient.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2016 eBusiness Information
+ *
+ * This file is part of OSM Contributor.
+ *
+ * OSM Contributor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OSM Contributor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OSM Contributor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.jawg.osmcontributor.flickr.rest;
+
+import retrofit.Callback;
+import retrofit.http.Body;
+import retrofit.http.Headers;
+import retrofit.http.POST;
+import retrofit.mime.TypedString;
+
+public interface FlickrAddTagClient {
+    @Headers({"Content-Type: application/x-www-form-urlencoded"})
+    @POST("/rest")
+    void addTags(@Body TypedString body, Callback<String> stringCallback);
+}

--- a/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrPhotoUtils.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrPhotoUtils.java
@@ -37,7 +37,6 @@ import retrofit.client.OkClient;
 public class FlickrPhotoUtils {
 
     public static RestAdapter adapter;
-    public static RestAdapter adapterOauth;
 
     public static RestAdapter getAdapter() {
         if (adapter == null) {
@@ -61,27 +60,26 @@ public class FlickrPhotoUtils {
     }
 
     public static RestAdapter getAdapter(final Map<String, String> oAuthParams) {
-        if (adapterOauth == null) {
-            OkHttpClient okHttpClient = new OkHttpClient();
-            try {
-                SSLSocketFactory NoSSLv3Factory = new NoSSLv3SocketFactory(new URL("https://api.flickr.com/services"));
-                okHttpClient.setSslSocketFactory(NoSSLv3Factory);
-                adapterOauth = new RestAdapter.Builder()
-                        .setConverter(new StringConverter())
-                        .setEndpoint("https://api.flickr.com/services")
-                        .setClient(new OkClient(okHttpClient)).setRequestInterceptor(new RequestInterceptor() {
-                            @Override
-                            public void intercept(RequestFacade request) {
-                                request.addHeader("Authorization", FlickrSecurityUtils.getAuthorizationHeader(oAuthParams));
-                            }
-                        })
-                        .setLogLevel(RestAdapter.LogLevel.FULL).setLog(new AndroidLog("---------------------->"))
-                        .build();
-            } catch (MalformedURLException e) {
-
-            } catch (IOException e) {
-
-            }
+        RestAdapter adapterOauth = null;
+        OkHttpClient okHttpClient = new OkHttpClient();
+        try {
+            SSLSocketFactory NoSSLv3Factory = new NoSSLv3SocketFactory(new URL("https://api.flickr.com/services"));
+            okHttpClient.setSslSocketFactory(NoSSLv3Factory);
+            adapterOauth = new RestAdapter.Builder()
+                    .setConverter(new StringConverter())
+                    .setEndpoint("https://api.flickr.com/services")
+                    .setClient(new OkClient(okHttpClient)).setRequestInterceptor(new RequestInterceptor() {
+                        @Override
+                        public void intercept(RequestFacade request) {
+                            request.addHeader("Authorization", FlickrSecurityUtils.getAuthorizationHeader(oAuthParams));
+                        }
+                    })
+                    .setLogLevel(RestAdapter.LogLevel.FULL).setLog(new AndroidLog("---------------------->"))
+                    .build();
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
         }
         return adapterOauth;
     }

--- a/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrPhotoUtils.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrPhotoUtils.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.net.ssl.SSLSocketFactory;
 
+import io.jawg.osmcontributor.BuildConfig;
 import io.jawg.osmcontributor.flickr.oauth.NoSSLv3SocketFactory;
 import io.jawg.osmcontributor.rest.utils.StringConverter;
 import retrofit.RequestInterceptor;
@@ -36,19 +37,21 @@ import retrofit.client.OkClient;
 
 public class FlickrPhotoUtils {
 
+    private static final String FLICKR_API_URL = "https://api.flickr.com/services";
+
     public static RestAdapter adapter;
 
     public static RestAdapter getAdapter() {
         if (adapter == null) {
             OkHttpClient okHttpClient = new OkHttpClient();
             try {
-                SSLSocketFactory NoSSLv3Factory = new NoSSLv3SocketFactory(new URL("https://api.flickr.com/services"));
+                SSLSocketFactory NoSSLv3Factory = new NoSSLv3SocketFactory(new URL(FLICKR_API_URL));
                 okHttpClient.setSslSocketFactory(NoSSLv3Factory);
                 adapter = new RestAdapter.Builder()
                         .setConverter(new StringConverter())
-                        .setEndpoint("https://api.flickr.com/services")
+                        .setEndpoint(FLICKR_API_URL)
                         .setClient(new OkClient(okHttpClient))
-                        .setLogLevel(RestAdapter.LogLevel.FULL).setLog(new AndroidLog("---------------------->"))
+                        .setLogLevel((BuildConfig.DEBUG) ? RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.BASIC).setLog(new AndroidLog("---------------------->"))
                         .build();
             } catch (MalformedURLException e) {
 
@@ -63,18 +66,18 @@ public class FlickrPhotoUtils {
         RestAdapter adapterOauth = null;
         OkHttpClient okHttpClient = new OkHttpClient();
         try {
-            SSLSocketFactory NoSSLv3Factory = new NoSSLv3SocketFactory(new URL("https://api.flickr.com/services"));
+            SSLSocketFactory NoSSLv3Factory = new NoSSLv3SocketFactory(new URL(FLICKR_API_URL));
             okHttpClient.setSslSocketFactory(NoSSLv3Factory);
             adapterOauth = new RestAdapter.Builder()
                     .setConverter(new StringConverter())
-                    .setEndpoint("https://api.flickr.com/services")
+                    .setEndpoint(FLICKR_API_URL)
                     .setClient(new OkClient(okHttpClient)).setRequestInterceptor(new RequestInterceptor() {
                         @Override
                         public void intercept(RequestFacade request) {
                             request.addHeader("Authorization", FlickrSecurityUtils.getAuthorizationHeader(oAuthParams));
                         }
                     })
-                    .setLogLevel(RestAdapter.LogLevel.FULL).setLog(new AndroidLog("---------------------->"))
+                    .setLogLevel((BuildConfig.DEBUG) ? RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.BASIC).setLog(new AndroidLog("---------------------->"))
                     .build();
         } catch (MalformedURLException e) {
             e.printStackTrace();

--- a/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrSecurityUtils.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrSecurityUtils.java
@@ -26,7 +26,6 @@ import java.net.URLEncoder;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import java.util.Set;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -82,12 +81,12 @@ public class FlickrSecurityUtils {
                     .append(SEPARATOR);
 
             StringBuilder paramsBuilder = new StringBuilder();
-            Set<Map.Entry<String, String>> values = params.entrySet();
-            for (Map.Entry<String, String> param : values) {
+            for (Map.Entry<String, String> param : params.entrySet()) {
                 paramsBuilder.append(param.getKey()).append(EQUAL).append(param.getValue()).append(SEPARATOR);
             }
 
-            String paramsEncoded = URLEncoder.encode(paramsBuilder.deleteCharAt(paramsBuilder.lastIndexOf(SEPARATOR)).toString(), UTF_8);
+            String urlToEncode = (paramsBuilder.lastIndexOf(SEPARATOR) >= 0) ? paramsBuilder.deleteCharAt(paramsBuilder.lastIndexOf(SEPARATOR)).toString() : paramsBuilder.toString();
+            String paramsEncoded = URLEncoder.encode(urlToEncode, UTF_8);
             return urlBuilder.append(paramsEncoded).toString();
         } catch (UnsupportedEncodingException e) {
             return null;

--- a/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrSecurityUtils.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrSecurityUtils.java
@@ -18,6 +18,8 @@
  */
 package io.jawg.osmcontributor.flickr.util;
 
+import android.util.Log;
+
 import com.flickr4java.flickr.util.Base64;
 import com.github.scribejava.core.model.Verb;
 
@@ -29,6 +31,8 @@ import java.util.Map;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+
+import io.jawg.osmcontributor.BuildConfig;
 
 
 public class FlickrSecurityUtils {
@@ -44,6 +48,8 @@ public class FlickrSecurityUtils {
 
     private static final String UTF_8 = "UTF-8";
 
+    private static final String TAG = "FlickrSecurityUtils";
+
     /*=========================================*/
     /*------------UTILS METHOD-----------------*/
     /*=========================================*/
@@ -58,6 +64,9 @@ public class FlickrSecurityUtils {
             Mac mac = Mac.getInstance(HMAC_SHA1);
             mac.init(new SecretKeySpec(key.getBytes(), HMAC_SHA1));
             byte[] digest = mac.doFinal(convertedRequestUrl.getBytes());
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, convertedRequestUrl);
+            }
             return new String(Base64.encode(digest));
         } catch (NoSuchAlgorithmException | InvalidKeyException exception) {
             return null;
@@ -85,7 +94,8 @@ public class FlickrSecurityUtils {
                 paramsBuilder.append(param.getKey()).append(EQUAL).append(param.getValue()).append(SEPARATOR);
             }
 
-            String urlToEncode = (paramsBuilder.lastIndexOf(SEPARATOR) >= 0) ? paramsBuilder.deleteCharAt(paramsBuilder.lastIndexOf(SEPARATOR)).toString() : paramsBuilder.toString();
+            int lastIndexSep = paramsBuilder.lastIndexOf(SEPARATOR);
+            String urlToEncode = (lastIndexSep >= 0) ? paramsBuilder.deleteCharAt(lastIndexSep).toString() : paramsBuilder.toString();
             String paramsEncoded = URLEncoder.encode(urlToEncode, UTF_8);
             return urlBuilder.append(paramsEncoded).toString();
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrUploadUtils.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/util/FlickrUploadUtils.java
@@ -27,10 +27,12 @@ import java.util.Map;
 
 import javax.net.ssl.SSLSocketFactory;
 
+import io.jawg.osmcontributor.BuildConfig;
 import io.jawg.osmcontributor.flickr.oauth.NoSSLv3SocketFactory;
 import io.jawg.osmcontributor.rest.utils.StringConverter;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
+import retrofit.android.AndroidLog;
 import retrofit.client.OkClient;
 
 public class FlickrUploadUtils {
@@ -51,7 +53,9 @@ public class FlickrUploadUtils {
                             public void intercept(RequestFacade request) {
                                 request.addHeader("Authorization", FlickrSecurityUtils.getAuthorizationHeader(oAuthParams));
                             }
-                        }).build();
+                        })
+                        .setLogLevel((BuildConfig.DEBUG) ? RestAdapter.LogLevel.HEADERS_AND_ARGS : RestAdapter.LogLevel.BASIC).setLog(new AndroidLog("---------------------->"))
+                        .build();
             } catch (MalformedURLException e) {
 
             } catch (IOException e) {

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -223,6 +223,12 @@
   <!--Android 6.0 dialog messages-->
   <string name="permissions_title">Permissions nécessaires</string>
   <string name="permissions_information">L\'accès à la localisation et en écriture au téléphone sont nécessaires pour gérer la carte et la base de données. Nous ne récupérons aucunes données personnelles sur votre téléphone. En refusant ces deux permissions, l\'application ne peut fonctionner correctement.</string>
+  <!-- Pictures -->
+  <string name="picture_sent_failure">Erreur lors de l\'envoi de la photo, réessayer</string>
+  <string name="flickr_communication_failure">La communication avec Flickr a échoué, réessayer</string>
+  <string name="picture_sent_success">Votre photo a été envoyée. Elle s\'affichera dans quelques minutes</string>
+  <string name="poi_association_failure">Erreur lors de l\'association au POI</string>
+
   <string name="malformated_tag">La valeur de ce tag ne respecte pas les conventions OpenStreetMap</string>
   <string name="malformated_value">Valeur actuelle :</string>
   <string name="flickr_title">Compte Flickr requis</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -283,6 +283,12 @@
         Without this permissions, the application can\'t work correctly.
     </string>
 
+    <!-- Pictures -->
+    <string name="picture_sent_failure">Error occurred when sending picture, please retry</string>
+    <string name="flickr_communication_failure">Can\'t communicate with Flickr, please retry</string>
+    <string name="picture_sent_success">Picture was successfully sent. It will be available in a few minutes</string>
+    <string name="poi_association_failure">Can\'t associate picture to POI</string>
+
     <string name="malformated_tag">The value of this tag doesn\'t respect OSM conventions</string>
     <string name="malformated_value">Current value: </string>
 


### PR DESCRIPTION
This pull request edits the PhotoActivity to add, on a new Flickr picture, the OSM ID of the current POI, when this one already exists in OSM database. It creates an `osm:node=xxxx` or `osm:way=xxxx` machine tag on the newly taken picture. Changes to the API call were needed, as the method in Flickr API must be called in HTTP using `POST`. Calling it by `GET` didn't allowed to create machine tags having special characters.