### PR TITLE
Show only explicitly linked Flickr pictures for a given POI

### DIFF
--- a/src/main/java/io/jawg/osmcontributor/flickr/event/PhotosFoundEvent.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/event/PhotosFoundEvent.java
@@ -26,11 +26,18 @@ public class PhotosFoundEvent {
 
     private List<List<Size>> photos;
 
-    public PhotosFoundEvent(List<List<Size>> photos) {
+    private Long poiId;
+
+    public PhotosFoundEvent(List<List<Size>> photos, Long poiId) {
         this.photos = photos;
+        this.poiId = poiId;
     }
 
     public List<List<Size>> getPhotos() {
         return photos;
+    }
+
+    public Long getPoiId() {
+        return poiId;
     }
 }

--- a/src/main/java/io/jawg/osmcontributor/flickr/rest/asynctask/GetFlickrPhotos.java
+++ b/src/main/java/io/jawg/osmcontributor/flickr/rest/asynctask/GetFlickrPhotos.java
@@ -49,7 +49,8 @@ public class GetFlickrPhotos extends AsyncTask<Void, Void, List<List<Size>>> {
      */
     private static final Integer RADIUS = 1;
 
-    private static final String[] TAGS = {"openstreetmap"};
+    private static final String[] TAGS_ARRAY = { "openstreetmap" };
+    private static final List<String> TAGS = Arrays.asList(TAGS_ARRAY);
 
     /*=========================================*/
     /*------------ATTRIBUTES-------------------*/
@@ -78,7 +79,7 @@ public class GetFlickrPhotos extends AsyncTask<Void, Void, List<List<Size>>> {
     @Override
     protected List<List<Size>> doInBackground(Void... params) {
         //Create search tags list
-        ArrayList<String> searchTags = new ArrayList<String>(Arrays.asList(TAGS));
+        ArrayList<String> searchTags = new ArrayList<String>(TAGS);
         searchTags.add(
                 new StringBuilder("osm:")
                         .append((featurePoi.getWay()) ? "way" : "node")
@@ -93,15 +94,18 @@ public class GetFlickrPhotos extends AsyncTask<Void, Void, List<List<Size>>> {
         parameters.setRadius(RADIUS);
         parameters.setTags(searchTags.toArray(new String[searchTags.size()]));
         parameters.setSort(SearchParameters.INTERESTINGNESS_DESC);
-        try {
-            PhotoList<Photo> photos = flickr.getPhotosInterface().search(parameters, limitPerPage, nbPage);
-            List<List<Size>> photosList = new ArrayList<>();
-            for (Photo photo : photos) {
-                photosList.add((List<Size>) flickr.getPhotosInterface().getSizes(photo.getId()));
+
+        if (!isCancelled()) {
+            try {
+                PhotoList<Photo> photos = flickr.getPhotosInterface().search(parameters, limitPerPage, nbPage);
+                List<List<Size>> photosList = new ArrayList<>();
+                for (Photo photo : photos) {
+                    photosList.add((List<Size>) flickr.getPhotosInterface().getSizes(photo.getId()));
+                }
+                return photosList;
+            } catch (FlickrException e) {
+                e.printStackTrace();
             }
-            return photosList;
-        } catch (FlickrException e) {
-            e.printStackTrace();
         }
         return null;
     }

--- a/src/main/java/io/jawg/osmcontributor/ui/activities/PhotoActivity.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/activities/PhotoActivity.java
@@ -194,7 +194,7 @@ public class PhotoActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_photo);
         ButterKnife.bind(this);
-        EventBus.getDefault().register(this);
+
         application = (OsmTemplateApplication) getApplication();
         flickrOAuth = new FlickrOAuth();
         application.getOsmTemplateComponent().inject(this);
@@ -221,12 +221,19 @@ public class PhotoActivity extends AppCompatActivity {
         // Init listener and view
         initScrollListener();
         initOnClickItemListener();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        EventBus.getDefault().register(this);
         initView();
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
+    public void onPause() {
+        super.onPause();
+        EventBus.getDefault().unregister(this);
         if (asyncGetPhotos != null) {
             asyncGetPhotos.cancel(true);
         }

--- a/src/main/java/io/jawg/osmcontributor/ui/activities/PhotoActivity.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/activities/PhotoActivity.java
@@ -161,7 +161,7 @@ public class PhotoActivity extends AppCompatActivity {
     /*=========================================*/
     /*------------ATTRIBUTES-------------------*/
     /*=========================================*/
-    private Map<Long, ImageAdapter> imageAdapters;
+    private ImageAdapter imageAdapter;
 
     private int lastVisiblePos;
 
@@ -217,12 +217,19 @@ public class PhotoActivity extends AppCompatActivity {
         // Init parameters.
         latitude = getIntent().getDoubleExtra("latitude", 0);
         longitude = getIntent().getDoubleExtra("longitude", 0);
-        imageAdapters = new HashMap<Long, ImageAdapter>();
 
         // Init listener and view
         initScrollListener();
         initOnClickItemListener();
         initView();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (asyncGetPhotos != null) {
+            asyncGetPhotos.cancel(true);
+        }
     }
 
     /*=========================================*/
@@ -296,10 +303,6 @@ public class PhotoActivity extends AppCompatActivity {
 
     private void initView() {
         poiId = getIntent().getLongExtra("poiId", 0);
-        if (!imageAdapters.containsKey(poiId)) {
-            imageAdapters.put(poiId, new ImageAdapter(this, poiId));
-        }
-        gridPhotos.setAdapter(imageAdapters.get(poiId));
 
         if (ImageAdapter.getPhotoUrlsCachedThumbs(poiId) == null || ImageAdapter.getPhotoUrlsCachedThumbs(poiId).isEmpty()) {
             gridPhotos.setVisibility(View.INVISIBLE);
@@ -361,9 +364,12 @@ public class PhotoActivity extends AppCompatActivity {
         if (photos != null && !photos.isEmpty() && photosFoundEvent.getPoiId().equals(poiId)) {
             noPhotos.setVisibility(View.INVISIBLE);
             gridPhotos.setVisibility(View.VISIBLE);
+            imageAdapter = new ImageAdapter(this, poiId);
+            gridPhotos.setAdapter(imageAdapter);
+
             for (List<Size> size : photos) {
-                imageAdapters.get(poiId).addPhoto(size.get(Size.SQUARE).getSource(), poiId, Size.SQUARE);
-                imageAdapters.get(poiId).addPhoto(size.get(Size.ORIGINAL).getSource(), poiId, Size.ORIGINAL);
+                imageAdapter.addPhoto(size.get(Size.SQUARE).getSource(), poiId, Size.SQUARE);
+                imageAdapter.addPhoto(size.get(Size.ORIGINAL).getSource(), poiId, Size.ORIGINAL);
             }
         } else {
             noPhotos.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Picture gallery for a POI now only shows the pictures that were explicitly associated to this POI (according to Flickr machine tags `osm:node=xxxx`), instead of all pictures by geographical proximity.