### PR TITLE
[FIX] Tailing spaces cause loging fail

### DIFF
--- a/src/main/java/io/jawg/osmcontributor/login/StoreLoginManager.java
+++ b/src/main/java/io/jawg/osmcontributor/login/StoreLoginManager.java
@@ -74,7 +74,7 @@ public class StoreLoginManager extends LoginManager {
                 permissions = osmRestClient.getPermissions(oAuthRequest.getParams());
             } else {
                 // Basic Auth connection
-                String authorization = "Basic " + Base64.encodeToString((login + ":" + password).getBytes(), Base64.NO_WRAP);
+                String authorization = "Basic " + Base64.encodeToString((login.trim() + ":" + password).getBytes(), Base64.NO_WRAP);
                 permissions = osmRestClient.getPermissions(authorization);
             }
 


### PR DESCRIPTION
Sometimes the keyboard may suggest the e-mail on login, picking the e-mail like this may add a trailing space.
This patch is to remove the tailing spaces before connecting.