### PR TITLE
[FIX] h2geo-presets spec: required tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // add -Pfoss=true to gradlew args to build a version with no Crashlytics/Google analytics
         if(!project.hasProperty('foss')) {
@@ -97,7 +97,7 @@ android {
 
     defaultConfig {
         applicationId "io.jawg.osmcontributor"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 25
         versionCode 24
         versionName appVersion
@@ -123,8 +123,8 @@ android {
 
         debug {
             versionNameSuffix ".debug-3"
-
-            buildConfigField "String", "BASE_OSM_URL", '"https://master.apis.dev.openstreetmap.org/api/0.6/"'
+            buildConfigField "String", "BASE_OSM_URL", '"https://www.openstreetmap.org/api/0.6/"'
+            //buildConfigField "String", "BASE_OSM_URL", '"https://master.apis.dev.openstreetmap.org/api/0.6/"'
         }
     }
 

--- a/src/bus/res/values/strings.xml
+++ b/src/bus/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <string name="name" translatable="false">Jungle Bus</string>
     <string name="poi_creation">Place your stop</string>
     <string name="delete_poi">Delete</string>

--- a/src/main/java/io/jawg/osmcontributor/login/StoreLoginManager.java
+++ b/src/main/java/io/jawg/osmcontributor/login/StoreLoginManager.java
@@ -20,12 +20,14 @@ package io.jawg.osmcontributor.login;
 
 import android.util.Base64;
 
+
 import com.github.scribejava.core.model.Verb;
 
 import org.greenrobot.eventbus.EventBus;
 
 import java.util.Map;
 
+import io.jawg.osmcontributor.BuildConfig;
 import io.jawg.osmcontributor.database.preferences.LoginPreferences;
 import io.jawg.osmcontributor.rest.clients.OsmRestClient;
 import io.jawg.osmcontributor.rest.dtos.osm.OsmDto;
@@ -57,28 +59,30 @@ public class StoreLoginManager extends LoginManager {
      */
     @Override
     public boolean isValidLogin(final String login, final String password) {
-        try {
-            OsmDto permissions = null;
-            Map<String, String> oAuthParams = loginPreferences.retrieveOAuthParams();
 
+        try {
+                OsmDto permissions;
+                Map<String, String> oAuthParams = loginPreferences.retrieveOAuthParams();
             // OAuth connection
             if (oAuthParams != null) {
-                String requestUrl = "https://www.openstreetmap.org/api/0.6/permissions";
-
+                String requestUrl = BuildConfig.BASE_OSM_URL + "permissions";
                 OAuthRequest oAuthRequest = new OAuthRequest(oAuthParams.get(CONSUMER_PARAM), oAuthParams.get(CONSUMER_SECRET_PARAM));
                 oAuthRequest.initParam(OAuthParams.getOAuthParams().put(TOKEN_PARAM, oAuthParams.get(TOKEN_PARAM)).toMap());
                 oAuthRequest.setOAuthToken(oAuthParams.get(TOKEN_PARAM));
                 oAuthRequest.setOAuthTokenSecret(oAuthParams.get(TOKEN_SECRET_PARAM));
                 oAuthRequest.setRequestUrl(requestUrl);
                 oAuthRequest.signRequest(Verb.GET);
-                permissions = osmRestClient.getPermissions(oAuthRequest.getParams());
+                oAuthRequest.encodeParams();
+                String headerRequest = oAuthRequest.getOAuthHeader();
+                permissions = osmRestClient.getPermissions(headerRequest);
+
             } else {
                 // Basic Auth connection
                 String authorization = "Basic " + Base64.encodeToString((login.trim() + ":" + password).getBytes(), Base64.NO_WRAP);
                 permissions = osmRestClient.getPermissions(authorization);
             }
 
-            if (permissions.getPermissionsDto() != null && permissions.getPermissionsDto().getPermissionDtoList() != null) {
+             if (permissions.getPermissionsDto() != null && permissions.getPermissionsDto().getPermissionDtoList() != null) {
                 for (PermissionDto permissionDto : permissions.getPermissionsDto().getPermissionDtoList()) {
                     if ("allow_write_api".equals(permissionDto.getName())) {
                         return true;

--- a/src/main/java/io/jawg/osmcontributor/rest/CommonSyncModule.java
+++ b/src/main/java/io/jawg/osmcontributor/rest/CommonSyncModule.java
@@ -21,6 +21,7 @@ package io.jawg.osmcontributor.rest;
 import com.google.gson.Gson;
 import com.squareup.okhttp.OkHttpClient;
 
+
 import org.simpleframework.xml.convert.AnnotationStrategy;
 import org.simpleframework.xml.core.Persister;
 import org.simpleframework.xml.strategy.Strategy;
@@ -33,9 +34,11 @@ import dagger.Provides;
 import io.jawg.osmcontributor.rest.mappers.JodaTimeDateTimeTransform;
 import io.jawg.osmcontributor.rest.utils.AuthenticationRequestInterceptor;
 
+
 @Module
 @Singleton
 public class CommonSyncModule {
+
     @Provides
     OkHttpClient getOkHttpClient(AuthenticationRequestInterceptor interceptor) {
         final OkHttpClient client = new OkHttpClient();

--- a/src/main/java/io/jawg/osmcontributor/rest/clients/OsmRestClient.java
+++ b/src/main/java/io/jawg/osmcontributor/rest/clients/OsmRestClient.java
@@ -32,6 +32,7 @@ import retrofit.http.Path;
 import retrofit.http.Query;
 import retrofit.http.QueryMap;
 
+
 /**
  * Rest interface for requests to OpenStreetMap.
  */
@@ -98,8 +99,18 @@ public interface OsmRestClient {
      * @return The id of the created ChangeSet.
      */
     @PUT("/changeset/create")
-    String addChangeSet(@Body OsmDto osmDto);
+    String addChangeSet(@Header("Authorization") String auth, @Body OsmDto osmDto);
 
+    /**
+     * Create a ChangeSet.
+     *
+     * @param osmDto an OsmDto containing a ChangeSetDto.
+     *               It is recommended to add the tags "comment=[description]" and "created-by=[user]"
+     *               to the ChangeSetDto.
+     * @return The id of the created ChangeSet.
+     */
+    @PUT("/changeset/create")
+    String addChangeSet(@Body OsmDto osmDto);
     /**
      * Close the changeSet.
      *

--- a/src/main/java/io/jawg/osmcontributor/rest/managers/OSMSyncWayManager.java
+++ b/src/main/java/io/jawg/osmcontributor/rest/managers/OSMSyncWayManager.java
@@ -171,7 +171,7 @@ public class OSMSyncWayManager implements SyncWayManager {
         final List<Long> ids = poiNodeRefDao.queryAllUpdated();
         List<Poi> pois = new ArrayList<>();
 
-        if (ids != null) {
+        if (ids != null && !ids.isEmpty()) {
             OSMProxy.Result<List<Poi>> result = osmProxy.proceed(new OSMProxy.NetworkAction<List<Poi>>() {
                 @Override
                 public List<Poi> proceed() {

--- a/src/main/java/io/jawg/osmcontributor/rest/security/GoogleOAuthManager.java
+++ b/src/main/java/io/jawg/osmcontributor/rest/security/GoogleOAuthManager.java
@@ -70,17 +70,17 @@ public class GoogleOAuthManager {
                     if (dialog.isProgressing()) {
                         dialog.stopProgressBar();
                     }
-                    // Get the tokens in hidden input in the html page
-                    webView.loadUrl("javascript:Android.showToken(" +
-                            "OSM.oauth_token " +
-                            "+ ' ' " +
-                            "+ OSM.oauth_token_secret" +
-                            "+ ' ' " +
-                            "+ OSM.oauth_consumer_key" +
-                            "+ ' ' " +
-                            "+ OSM.oauth_consumer_secret)");
-                }
 
+                    webView.loadUrl("javascript:Android.showToken(" +
+                            "document.getElementsByTagName('head')[0].getAttribute('data-token') " +
+                            "+ ' ' +" +
+                            "document.getElementsByTagName('head')[0].getAttribute('data-token-secret') " +
+                            "+' '+" +
+                            "document.getElementsByTagName('head')[0].getAttribute('data-consumer-key')" +
+                            "+' '+" +
+                            "document.getElementsByTagName('head')[0].getAttribute('data-consumer-secret'));");
+
+                }
                 if (url.contains(OSM_NEW_USER_URL) && !url.equals(OSM_NEW_USER_URL)) {
                     dialog.startProgressBar();
                     // Skip the inscription page
@@ -147,6 +147,7 @@ public class GoogleOAuthManager {
                 }
             });
         }
+
 
         @JavascriptInterface
         @SuppressWarnings("unused")

--- a/src/main/java/io/jawg/osmcontributor/rest/security/OAuthParams.java
+++ b/src/main/java/io/jawg/osmcontributor/rest/security/OAuthParams.java
@@ -22,6 +22,7 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.UUID;
 
+
 import io.jawg.osmcontributor.rest.utils.MapParams;
 
 public class OAuthParams {
@@ -36,6 +37,7 @@ public class OAuthParams {
     public static final String SIGNATURE_METHOD = "HMAC-SHA1";
 
     public static MapParams<String, String> getOAuthParams() {
+
         return new MapParams<String, String>()
                 .put("oauth_timestamp", String.valueOf(new Timestamp(new Date().getTime()).getTime()).substring(0, 10))
                 .put("oauth_nonce", UUID.randomUUID().toString().substring(0, 6))

--- a/src/main/java/io/jawg/osmcontributor/rest/security/OAuthRequest.java
+++ b/src/main/java/io/jawg/osmcontributor/rest/security/OAuthRequest.java
@@ -18,12 +18,16 @@
  */
 package io.jawg.osmcontributor.rest.security;
 
+import com.flickr4java.flickr.util.Base64;
 import com.github.scribejava.core.model.Verb;
+
+
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Map;
 import java.util.TreeMap;
+
 
 public class OAuthRequest {
 
@@ -43,6 +47,12 @@ public class OAuthRequest {
     private String oAuthToken;
 
     private String oAuthTokenSecret;
+
+    private static final String ENC = "UTF-8";
+
+    private static final String HMAC_SHA1 = "HmacSHA1";
+
+    private static Base64 base64 = new Base64();
 
     /*=========================================*/
     /*------------CONSTRUCTORS-----------------*/
@@ -71,7 +81,7 @@ public class OAuthRequest {
         String convertedUrl = SecurityUtils.convertUrl(requestUrl, verb, params);
         if (convertedUrl != null) {
             params.put("oauth_signature", SecurityUtils.getSignatureFromRequest(convertedUrl,
-                    apiKeySecret + SEPARATOR + (oAuthTokenSecret == null ? "" : oAuthTokenSecret)));
+                    apiKeySecret + SEPARATOR + (oAuthTokenSecret == null ? "" : oAuthTokenSecret)).replace("\n", ""));
         }
     }
 

--- a/src/main/java/io/jawg/osmcontributor/ui/activities/AuthorisationInterceptor.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/activities/AuthorisationInterceptor.java
@@ -1,0 +1,72 @@
+package io.jawg.osmcontributor.ui.activities;
+
+
+import android.util.Base64;
+
+import com.github.scribejava.core.model.Verb;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import io.jawg.osmcontributor.database.preferences.LoginPreferences;
+import io.jawg.osmcontributor.rest.security.OAuthParams;
+import io.jawg.osmcontributor.rest.security.OAuthRequest;
+import timber.log.Timber;
+
+
+/**
+ * Created by ebiz on 03/07/17.
+ */
+
+public class AuthorisationInterceptor implements Interceptor {
+
+    public static final String CONSUMER_PARAM = "oauth_consumer_key";
+    public static final String TOKEN_PARAM = "oauth_token";
+    public static final String TOKEN_SECRET_PARAM = "oauth_token_secret";
+    public static final String CONSUMER_SECRET_PARAM = "oauth_consumer_secret_key";
+
+    LoginPreferences loginPreferences;
+
+    @Inject
+    public AuthorisationInterceptor(LoginPreferences loginPreferences) {
+        this.loginPreferences = loginPreferences;
+    }
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Map<String, String> oAuthParams = loginPreferences.retrieveOAuthParams();
+
+        if (oAuthParams != null) {
+            Request originalRequest = chain.request();
+            String requestUrl = originalRequest.urlString();
+
+            OAuthRequest oAuthRequest = new OAuthRequest(oAuthParams.get(CONSUMER_PARAM), oAuthParams.get(CONSUMER_SECRET_PARAM));
+            oAuthRequest.initParam(OAuthParams.getOAuthParams().put(TOKEN_PARAM, oAuthParams.get(TOKEN_PARAM)).toMap());
+            oAuthRequest.setOAuthToken(oAuthParams.get(TOKEN_PARAM));
+            oAuthRequest.setOAuthTokenSecret(oAuthParams.get(TOKEN_SECRET_PARAM));
+            oAuthRequest.setRequestUrl(requestUrl);
+            oAuthRequest.signRequest(Verb.valueOf(originalRequest.method()));
+            oAuthRequest.encodeParams();
+            Request.Builder finalRequest = originalRequest
+                    .newBuilder()
+                    .addHeader("Authorization", oAuthRequest.getOAuthHeader())
+                    .method(originalRequest.method(), originalRequest.body());
+            return chain.proceed(finalRequest.build());
+        } else {
+            // create Base64 encoded string
+            String authorization = "Basic " + Base64.encodeToString((loginPreferences.retrieveLogin() + ":" + loginPreferences.retrievePassword()).getBytes(), Base64.NO_WRAP);
+            Timber.i("AUTHORIZATION TEST");
+            return chain.proceed(chain
+                    .request()
+                    .newBuilder()
+                    .header("Authorization", authorization)
+                    .header("Accept", "text/xml")
+                    .build());
+        }
+    }
+}

--- a/src/main/java/io/jawg/osmcontributor/ui/adapters/TagsAdapter.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/adapters/TagsAdapter.java
@@ -367,7 +367,7 @@ public class TagsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 return;
 
             case SINGLE_CHOICE:
-                onBindViewHolder((TagRadioChoiceHolder) holder, position);
+                onBindViewHolder((TagRadioChoiceHolder) holder, position, tagItemList.get(position).isMandatory());
                 break;
 
             default:
@@ -502,7 +502,7 @@ public class TagsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
      * @param holder holder
      * @param position position
      */
-    private void onBindViewHolder(TagRadioChoiceHolder holder, int position) {
+    private void onBindViewHolder(TagRadioChoiceHolder holder, int position, boolean mandatory) {
         // Get tag item from list
         final TagItem tagItem = tagItemList.get(position);
         boolean isVisible = tagItem.isShow();
@@ -520,6 +520,12 @@ public class TagsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
         // List of radio buttons without undefined. Undefined is always showing
         RadioButton[] radioButtons = holder.getRadioButtons();
+
+        if (mandatory) {
+            RadioButton undefinedRadioButton = holder.getUndefinedRadioButton();
+            undefinedRadioButton.setEnabled(false);
+            undefinedRadioButton.setChecked(false);
+        }
 
         // Access element for values
         int pos = 0;

--- a/src/main/java/io/jawg/osmcontributor/ui/adapters/TagsAdapter.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/adapters/TagsAdapter.java
@@ -367,7 +367,7 @@ public class TagsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 return;
 
             case SINGLE_CHOICE:
-                onBindViewHolder((TagRadioChoiceHolder) holder, position, tagItemList.get(position).isMandatory());
+                onBindViewHolder((TagRadioChoiceHolder) holder, position);
                 break;
 
             default:
@@ -502,7 +502,7 @@ public class TagsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
      * @param holder holder
      * @param position position
      */
-    private void onBindViewHolder(TagRadioChoiceHolder holder, int position, boolean mandatory) {
+    private void onBindViewHolder(TagRadioChoiceHolder holder, int position) {
         // Get tag item from list
         final TagItem tagItem = tagItemList.get(position);
         boolean isVisible = tagItem.isShow();
@@ -521,10 +521,20 @@ public class TagsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         // List of radio buttons without undefined. Undefined is always showing
         RadioButton[] radioButtons = holder.getRadioButtons();
 
+        // `undefined` radio button
+        RadioButton undefinedRadioButton = holder.getUndefinedRadioButton();
+
+        // Get if the tag is mandatory
+        final boolean mandatory = tagItemList.get(position).isMandatory();
+
+        // If the tag is required, we disable the `undefined` radio button
         if (mandatory) {
-            RadioButton undefinedRadioButton = holder.getUndefinedRadioButton();
             undefinedRadioButton.setEnabled(false);
-            undefinedRadioButton.setChecked(false);
+        }
+
+        // If the tag value is `undefined`, we check the undefined radio button
+        if (tagItem.getValue() != null && tagItem.getValue().equals(TagItem.VALUE_UNDEFINED)) {
+            undefinedRadioButton.setChecked(true);
         }
 
         // Access element for values
@@ -546,7 +556,6 @@ public class TagsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
                     // Select radio if value is not undefined
                     if (tagItem.getValue() != null && tagItem.getValue().equals(values.get(pos))) {
-                        holder.getUndefinedRadioButton().setChecked(false);
                         radioButtons[i].setChecked(true);
                     }
                     pos++;

--- a/src/main/java/io/jawg/osmcontributor/ui/adapters/item/TagItem.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/adapters/item/TagItem.java
@@ -25,6 +25,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TagItem implements Parcelable {
+
+    public static final String VALUE_UNDEFINED = "undefined";
+
     private String key;
     private String value;
     private boolean mandatory;

--- a/src/main/java/io/jawg/osmcontributor/ui/dialogs/WebViewDialogFragment.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/dialogs/WebViewDialogFragment.java
@@ -31,6 +31,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Button;
@@ -92,6 +94,7 @@ public class WebViewDialogFragment extends DialogFragment {
         startProgressBar();
 
         webView.getSettings().setJavaScriptEnabled(true);
+        webView.getSettings().setUserAgentString("Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0");
         clearCookies(getActivity());
 
         webView.setWebViewClient(new WebViewClient() {
@@ -106,6 +109,12 @@ public class WebViewDialogFragment extends DialogFragment {
                 view.loadUrl(url);
                 isRedirect = true;
                 return true;
+            }
+
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+
+                return super.shouldInterceptRequest(view, request);
             }
 
             @Override

--- a/src/main/java/io/jawg/osmcontributor/ui/managers/PoiManager.java
+++ b/src/main/java/io/jawg/osmcontributor/ui/managers/PoiManager.java
@@ -70,6 +70,7 @@ import io.jawg.osmcontributor.model.events.ResetTypeDatabaseEvent;
 import io.jawg.osmcontributor.model.events.RevertFinishedEvent;
 import io.jawg.osmcontributor.rest.dtos.dma.H2GeoDto;
 import io.jawg.osmcontributor.rest.mappers.PoiTypeMapper;
+import io.jawg.osmcontributor.ui.adapters.item.TagItem;
 import io.jawg.osmcontributor.ui.events.map.ChangesInDB;
 import io.jawg.osmcontributor.ui.events.map.LastUsePoiTypeLoaded;
 import io.jawg.osmcontributor.ui.events.map.PleaseLoadLastUsedPoiType;
@@ -857,9 +858,14 @@ public class PoiManager {
 
         Map<String, String> defaultTags = new HashMap<>();
         for (PoiTypeTag poiTypeTag : poi.getType().getTags()) {
+            // If the tag is a multi-choice and not required, we set `undefined` by default
+            if (poiTypeTag.getTagType() == TagItem.Type.SINGLE_CHOICE && !poiTypeTag.getMandatory()) {
+                poiTypeTag.setValue(TagItem.VALUE_UNDEFINED);
+            }
             if (poiTypeTag.getValue() != null) { // default tags should be set in the corresponding POI
                 defaultTags.put(poiTypeTag.getKey(), poiTypeTag.getValue());
             }
+
         }
         poi.applyChanges(defaultTags);
 

--- a/src/main/res/layout/tag_item_radio.xml
+++ b/src/main/res/layout/tag_item_radio.xml
@@ -68,8 +68,7 @@
                         android:id="@+id/rb_1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/undefined_button_text"
-                        android:checked="true" />
+                        android:text="@string/undefined_button_text"/>
 
                     <RadioButton
                         android:id="@+id/rb_2"

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -22,6 +22,7 @@
 <resources>
   <string name="title_activity_edit_poi">Edition de poi</string>
   <string name="location_not_found">Impossible de trouver votre position</string>
+  <string name="undefined">non défini</string>
   <!--EDITION-->
   <string name="addValueDialogTitle">Modifier la valeur de : \"%1$s\"</string>
   <string name="addValueDialogAdd">Modifier</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="add_tag">Add a tag</string>
     <string name="tag_key">Key</string>
     <string name="tag_value">Value</string>
+    <string name="undefined">undefined</string>
 
     <!-- Map -->
     <string name="no_poi_name">This POI doesn\'t have a name</string>


### PR DESCRIPTION
By default, all single choice tags have the `undefined` radio button.
In some cases, a single choice tag may be required, therefore `undefined`
choice shouldn't be allowed.
With this patch, the `undefined` radio button is disabled and unselected
when a tag is required.

Fixes "required=true is not yet supported" at #86