### PR TITLE
Update mapnik.json

### DIFF
--- a/src/main/assets/mapnik.json
+++ b/src/main/assets/mapnik.json
@@ -5,9 +5,7 @@
     "osm": {
       "type": "raster",
       "tiles": [
-        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
       ],
       "tileSize": 128,
       "maxzoom": 19


### PR DESCRIPTION
`{s}.` is no longer recommended now that we support HTTP/2 + HTTP/3.